### PR TITLE
Updated Expo import for a gradient

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
 import generateGradient from "./generator";
+import { LinearGradient } from "expo-linear-gradient";
 
 export { generateGradient };
 
 export default ({ gradient, children, style }) => {
-  const LinearGradient = require("expo").LinearGradient;
   const generated = generateGradient(gradient, {
     width: style.width,
     height: style.height

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "peerDependencies": {
     "expo": "*",
+    "expo-linear-gradient": "*",
     "react": "*",
     "react-native": "*"
   }


### PR DESCRIPTION
Updated in regards to Expo's error message:

"The following APIs have moved to separate packages and importing them from the "expo" package is deprecated: LinearGradient.

1. Add correct versions of these packages to your project using:

   expo install expo-linear-gradient

   If "install" is not recognized as an expo command, update your expo-cli installation.

2. Change your imports so they use specific packages instead of the "expo" package:

 - import { LinearGradient } from 'expo' -> import { LinearGradient } from 'expo-linear-gradient'"