### PR TITLE
LinearGradient start & end property array deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,15 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
 import generateGradient from "./generator";
-import { LinearGradient } from "expo-linear-gradient";
 
 export { generateGradient };
 
 export default ({ gradient, children, style }) => {
+  // Avoid breaking this when people are not using expo :)
+  // find a better solution to expose either expo-linear-gradient or
+  // react-native-linear-gradient.
+  const { LinearGradient } = require("expo-linear-gradient");
+
   const generated = generateGradient(gradient, {
     width: style.width,
     height: style.height
@@ -20,6 +24,7 @@ export default ({ gradient, children, style }) => {
       </View>
     );
   }
+
   return (
     <LinearGradient style={style} {...generated[0]}>
       {children || null}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,14 @@
 {
   "name": "react-native-css-gradient",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "fast-memoize": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.1.tgz",
+      "integrity": "sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g=="
+    },
     "gradient-parser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://github.com/catalinmiron/react-native-css-gradient#readme",
   "main": "index.js",
   "dependencies": {
+    "fast-memoize": "^2.5.1",
     "gradient-parser": "0.1.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hi catalinmiron,

A big thanks for creating this library. 

I've set it up to use with the react-native-linear-gradient ( 2.5.4 ) library. In this setup, I get the following warnings ( screenshot ):

<img width="504" alt="Screen Shot 2019-06-10 at 4 39 21 pm" src="https://user-images.githubusercontent.com/896157/59177091-5180cd00-8b9e-11e9-9e26-9fda0007025a.png">

I'm not sure if this shows in Expo. The fix, however, is trivial.

```
    start: { x:center.x - xDiff, y:center.y - yDiff },
    end: { x:center.x + xDiff, y:center.y + yDiff }
```

Happy to send a PR if this fix doesn't break Expo.

Thanks